### PR TITLE
premission error

### DIFF
--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -185,11 +185,17 @@ class EntryNode(Node):
     def re_stat(self, lazy=False):
         self.linkto = None
         if os.path.islink(self.fullpath):
-            self.linkto = os.readlink(self.fullpath)
-
+            try:
+                self.linkto = os.readlink(self.fullpath)
+            except PermissionError:  # added eyal
+                self.stat = None
+            except FileNotFoundError:
+                self.stat = None
         if not lazy:
             try:
                 self.stat = os.stat(self.fullpath)
+            except PermissionError:  # added eyal
+                self.stat = None
             except FileNotFoundError:
                 self.stat = None
         else:


### PR DESCRIPTION
I think that fixes the permission error as in issue https://github.com/ipod825/vim-netranger/issues/28 .
That means when expanding a dir (in windows), if some of the child dirs are not accessible, it won't open the parent. Haven't checked it fully.