### PR TITLE
Major fixes, among them windows file handling

### DIFF
--- a/pythonx/netranger/fs.py
+++ b/pythonx/netranger/fs.py
@@ -178,11 +178,11 @@ class LocalFS(object):
             pickle.dump(arguments, f)
 
         if sudo:
-            Vim.AsyncRun('sudo {} {} {}'.format(self.ServerCmd, cmd, fname),
+            Vim.AsyncRun('sudo {} {} {}'.format(self.ServerCmd, cmd, fname).replace('\\','\\\\'),
                          on_exit=on_exit,
                          term=True)
         else:
-            Vim.AsyncRun('{} {} {}'.format(self.ServerCmd, cmd, fname),
+            Vim.AsyncRun('{} {} {}'.format(self.ServerCmd, cmd, fname).replace('\\','\\\\'),
                          on_stderr=on_stderr,
                          on_exit=on_exit)
 
@@ -197,6 +197,7 @@ class LocalFS(object):
 
     @classmethod
     def cp(self, src_arr, dst, sudo=False, on_exit=None):
+        print("uuu",src_arr,dst)
         self.exec_server_cmd('cp',
                              on_exit, {
                                  'src': src_arr,

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -1091,9 +1091,33 @@ class Netranger(object):
     1. BufEnter: on_bufenter. create/update NetRangerBuf.
     2. CursorMoved: on_cursormoved. update node highlighting and some othe stuff.
     """
+    def generate_and_ret_buf(self):
+        bufname = Vim.current.buffer.name
+        if len(bufname) > 0 and bufname[-1] == '~':
+            bufname = os.path.expanduser('~')
+        if not os.path.isdir(bufname):
+            return
+        if os.path.islink(bufname):
+            bufname = os.path.join(os.path.dirname(bufname),
+                                   os.readlink(bufname))
+        bufname = os.path.abspath(bufname)
+
+        # if self.buf_existed(bufname):
+            # self._bufs[Vim.current.buffer.number] =  self._wd2bufnum[bufname]
+        # else:
+        self.gen_new_buf(bufname)
+
+        return self._bufs[Vim.current.buffer.number]
+
+
+        
+
     @property
     def cur_buf(self):
-        return self._bufs[Vim.current.buffer.number]
+        if Vim.current.buffer.number in self._bufs:
+            return self._bufs[Vim.current.buffer.number]
+        else:
+            return self.generate_and_ret_buf()
 
     @property
     def cur_node(self):

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -420,6 +420,7 @@ class NetRangerBuf(object):
                 return '/'.join(sp).ljust(width)
             else:
                 total += len(sp[i]) - 1
+        return res[-1 * width:]
 
     def redraw_header_content(self):
         self._header_node.name = self.abbrev_cwd(self.winwidth).strip()

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -859,16 +859,16 @@ class NetRangerBuf(object):
             return
 
         if is_DIR:
-            Vim.command(f'{win_nr}hide')
+            Vim.command(f'silent! {win_nr}hide')
         else:
             if Vim.eval(f'getbufvar({bufnr}, "&buftype")') == 'terminal':
-                Vim.command(f'bwipeout! {bufnr}')
+                Vim.command(f'silent! bwipeout! {bufnr}')
             elif Vim.eval(f'getbufvar({bufnr}, "&modified")') == '1':
-                Vim.command(f'{win_nr}hide')
+                Vim.command(f'silent! {win_nr}hide')
             elif len(Vim.eval(f'win_findbuf({bufnr})')) > 1:
-                Vim.command(f'{win_nr}hide')
+                Vim.command(f'silent! {win_nr}hide')
             else:
-                Vim.command(f'bwipeout! {bufnr}')
+                Vim.command(f'silent! bwipeout! {bufnr}')
 
     def preview_on(self):
         """ Turn preview panel on. """

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -406,6 +406,8 @@ class NetRangerBuf(object):
         if len(res) <= width:
             return res.ljust(width)
 
+        res=res.replace('\\','/') #windows 
+        
         sp = res.split('/')
         szm1 = len(sp) - 1
         total = 2 * (szm1) + len(sp[-1])

--- a/pythonx/netranger/util.py
+++ b/pythonx/netranger/util.py
@@ -4,6 +4,10 @@ import sys
 
 def GenNetRangerScriptCmd(script):
     python = sys.executable
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+    if os.name == 'nt':
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        f'..\\{script}.py')
+    else:
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         f'../{script}.py')
     return f'{python} {path}'


### PR DESCRIPTION
Hi, 
I solved here few errors, some of which I didn't create an issue. 
curbuf handling was problematic in a way I don't fully remember. I think it threw an error about out of index of buffers. you probably saw it. 

`fixing issue #43, windows file operation not working` and `fixing windows 1` fixes windows file handling issue #43. 
It really solved FS operations in windows. The thing to note is  that you do replace `\\` with `\\\\` before calling vim commands , otherwise `\\` becomes `\`  and it becomes magic.

The silent thing is needed because of errors from time to time. 
The missing return caused an error as well. 


