### PR TITLE
Addsearchprog

### DIFF
--- a/pythonx/netranger/Vim.py
+++ b/pythonx/netranger/Vim.py
@@ -206,11 +206,11 @@ def debug(*msg):
 def WarningMsg(msg):
     vim.command(
         'unsilent echohl WarningMsg | unsilent echo "{}" | echohl None '.
-        format(msg.replace('"', '\\"')))
+        format(msg.replace('"', '\\"').replace('\\','\\\\')))
 
 
 def Echo(msg):
-    vim.command(f'unsilent echo "{msg}"')
+    vim.command('unsilent echo "%s"' % (msg.replace("\\","\\\\"),))
 
 
 def UserInput(hint, default=''):

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -2078,18 +2078,24 @@ class Netranger(object):
         # clear command line
         Vim.command('echo')
 
-    def _NETRSearchGTNext(self):
-        accept_line_nr = [n.name for n in self._cur_search_buf.nodes
-                          ].index(Vim.current.line) + 1
+    def _NETRSearchGTNext(self,forward):
+        if forward:
+            accept_line_nr = [n.name for n in self._cur_search_buf.nodes
+                              ].index(Vim.current.line) + 1
         
         self._NETRSearchStop(True)
-        nod=self.cur_buf.nodes[accept_line_nr-1]
-        print('zz',nod.name)
-        self.cur_buf.set_clineno_by_node(nod)
-        if nod.is_DIR:
-            self.NETRBufOpen()
-            # Vim.command("norm kztjj")
+        if forward:
+            nod=self.cur_buf.nodes[accept_line_nr-1]
+            self.cur_buf._redraw()
+            self.cur_buf.set_clineno_by_node(nod)
+            # self.cur_buf.update_nodes_and_redraw(force_redraw=True)
+            if nod.is_DIR:
+                self.NETRBufOpen()
+                self.NETRSearch()
+        else:
+            self.NETRParentDir()
             self.NETRSearch()
+
         Vim.command('echo')
 
     def _NETRSearchMove(self, binding):
@@ -2100,7 +2106,7 @@ class Netranger(object):
     def _NETRSearchMap(self):
         stop_template = 'cnoremap <buffer> {} <cmd>python3 ranger._NETRSearchStop({})<cr><cr>'
         move_template = 'cnoremap <buffer><nowait> {} <cmd>python3 ranger._NETRSearchMove("{}")<cr>'
-        gt_template = 'cnoremap <buffer><nowait> {} <cmd>python3 ranger._NETRSearchGTNext()<cr>'
+        gt_template = 'cnoremap <buffer><nowait> {} <cmd>python3 ranger._NETRSearchGTNext({})<cr>'
         Vim.command(stop_template.format('<cr>', True))
         Vim.command(stop_template.format('<esc>', False))
         Vim.command(stop_template.format('<c-c>', False))
@@ -2108,7 +2114,8 @@ class Netranger(object):
         Vim.command(move_template.format('<c-k>', '<up'))
         Vim.command(move_template.format('<down>', '<down'))
         Vim.command(move_template.format('<up>', '<up'))
-        Vim.command(gt_template.format('<c-/>'))
+        Vim.command(gt_template.format('<c-/>',True))
+        Vim.command(gt_template.format('<M-/>',False))
 
     def NETRSearch(self):
         self._cur_search_buf = self.cur_buf

--- a/pythonx/netranger/netranger.py
+++ b/pythonx/netranger/netranger.py
@@ -2031,8 +2031,10 @@ class Netranger(object):
 
         ignore_case = False
         if pattern and pattern:
-            if (Vim.options['smartcase'] and re.match(
-                    '[A-Z]', pattern)) or not Vim.options['ignorecase']:
+            if (Vim.options['smartcase'] and
+                    re.match("(?=.*[a-z])(?=.*[A-Z])",pattern)) and not Vim.options['ignorecase']:
+                # if (Vim.options['smartcase'] and re.match(
+                # '[A-Z]', pattern)) or not Vim.options['ignorecase']:
                 pattern = re.compile('.*' + pattern)
             else:
                 pattern = re.compile('.*' + pattern, re.IGNORECASE)
@@ -2076,6 +2078,20 @@ class Netranger(object):
         # clear command line
         Vim.command('echo')
 
+    def _NETRSearchGTNext(self):
+        accept_line_nr = [n.name for n in self._cur_search_buf.nodes
+                          ].index(Vim.current.line) + 1
+        
+        self._NETRSearchStop(True)
+        nod=self.cur_buf.nodes[accept_line_nr-1]
+        print('zz',nod.name)
+        self.cur_buf.set_clineno_by_node(nod)
+        if nod.is_DIR:
+            self.NETRBufOpen()
+            # Vim.command("norm kztjj")
+            self.NETRSearch()
+        Vim.command('echo')
+
     def _NETRSearchMove(self, binding):
         if binding[0] == '<':
             binding = f'\{binding}>'
@@ -2084,6 +2100,7 @@ class Netranger(object):
     def _NETRSearchMap(self):
         stop_template = 'cnoremap <buffer> {} <cmd>python3 ranger._NETRSearchStop({})<cr><cr>'
         move_template = 'cnoremap <buffer><nowait> {} <cmd>python3 ranger._NETRSearchMove("{}")<cr>'
+        gt_template = 'cnoremap <buffer><nowait> {} <cmd>python3 ranger._NETRSearchGTNext()<cr>'
         Vim.command(stop_template.format('<cr>', True))
         Vim.command(stop_template.format('<esc>', False))
         Vim.command(stop_template.format('<c-c>', False))
@@ -2091,6 +2108,7 @@ class Netranger(object):
         Vim.command(move_template.format('<c-k>', '<up'))
         Vim.command(move_template.format('<down>', '<down'))
         Vim.command(move_template.format('<up>', '<up'))
+        Vim.command(gt_template.format('<c-/>'))
 
     def NETRSearch(self):
         self._cur_search_buf = self.cur_buf


### PR DESCRIPTION
This add options of <c-/> and <m-/> during search in order to goto dir and open search rapidly. 
There is a glitch in which cursor seen twice after revisit . And also, need to press many escapes to quit search.
Still good. Also, added ignore casing the right way. 
Also, forgot something in windows fix (nice to have). 

Sorry, I didn't want to invest some time  reorganizing commits .